### PR TITLE
Fix API Deployment Failure by Adding `six` Module to requirements.txt

### DIFF
--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -8,3 +8,4 @@ azure-identity == 1.21.0
 azure-keyvault-secrets == 4.4.*
 opentelemetry-instrumentation-fastapi == 0.42b0
 azure-monitor-opentelemetry-exporter == 1.0.0b19
+six == 1.17.0


### PR DESCRIPTION
Fixes issue https://github.com/Azure-Samples/todo-python-mongo/issues/7.  This PR resolves it by adding a `six` module to the [src/api/requirements.txt](https://github.com/Azure-Samples/todo-python-mongo-aca/blob/main/src/api/requirements.txt).

@rajeshkamal5050 and @vhvb1989 for notification.


