### PR TITLE
Update service naming "Cosmos DB for MongoDB API" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ products:
 - azure-pipelines
 urlFragment: todo-python-mongo-aca
 name: Containerized React Web App with Python API and MongoDB on Azure
-description: A complete ToDo app with Python FastAPI and Azure Cosmos API for MongoDB for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
+description: A complete ToDo app with Python FastAPI and Azure DocumentDB (with MongoDB compatibility) for storage. Uses Azure Developer CLI (azd) to build, deploy, and monitor
 ---
 <!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
 
@@ -84,7 +84,7 @@ azd up
 This application utilizes the following Azure resources:
 
 - [**Azure Container Apps**](https://docs.microsoft.com/azure/container-apps/) to host the Web frontend and API backend
-- [**Azure Cosmos DB API for MongoDB**](https://docs.microsoft.com/azure/cosmos-db/mongodb/mongodb-introduction) for storage
+- [**Azure DocumentDB (with MongoDB compatibility)**](https://learn.microsoft.com/azure/documentdb/) for storage
 - [**Azure Monitor**](https://docs.microsoft.com/azure/azure-monitor/) for monitoring and logging
 - [**Azure Key Vault**](https://docs.microsoft.com/azure/key-vault/) for securing secrets
 


### PR DESCRIPTION
Update mentions of previous service name  "Cosmos DB for MongoDB API" to "Azure DocumentDB (with MongoDB compatibility) and associated links. 